### PR TITLE
Fix verifiable build action

### DIFF
--- a/.github/workflows/ci-verified.yml
+++ b/.github/workflows/ci-verified.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  ANCHOR_CLI_VERSION: 0.26.0
+  ANCHOR_CLI_VERSION: 0.27.0
 
 jobs:
   build:
@@ -18,12 +18,12 @@ jobs:
 
       - name: Install Anchor CLI
         run: |
-          npm install -g @project-serum/anchor-cli@${{ env.ANCHOR_CLI_VERSION }}
+          npm install -g @coral-xyz/anchor-cli@${{ env.ANCHOR_CLI_VERSION }}
           anchor --version
       - name: Verifiable Build
         run: |
           echo "APP_NAME=$(cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[0].name')" >> $GITHUB_ENV 
-          anchor build --verifiable
+          anchor build --verifiable --docker-image projectserum/build:v0.27.0
       - name: Generate Checksum
         run: |
           echo "CHECKSUM=$(sha256sum ./target/verifiable/${{ env.APP_NAME }}.so | head -c 64)" >> $GITHUB_ENV


### PR DESCRIPTION
Similar issue had to be fixed with other repos. It has to do with anchor version not supporting older versions of solana